### PR TITLE
Refactor Azure DevOps service request/response models

### DIFF
--- a/src/AzureDevopsService/AzureDevopsService.API/AzureDevopsEndpoints.cs
+++ b/src/AzureDevopsService/AzureDevopsService.API/AzureDevopsEndpoints.cs
@@ -38,9 +38,9 @@ public static class AzureDevopsEndpoints
             return Results.Ok(result.AsT0);
         });
 
-        _ = app.MapPost("/ProjectByOrganization", async (IProjectService workItemExternalService, AllProjectUnderOrganizationRequest request) =>
+        _ = app.MapPost("/ProjectByOrganization", async (IProjectService workItemExternalService, GetOrganizationProjectsRequest request) =>
         {
-            OneOf<AllProjectResponce, CustomProblemDetailsResponce> result = await workItemExternalService.AllProjectUnderOrganization(request);
+            OneOf<OrganizationProjects, CustomProblemDetailsResponce> result = await workItemExternalService.AllProjectUnderOrganization(request);
 
             if (result.IsT1)
             {

--- a/src/AzureDevopsService/AzureDevopsService.Application/Featurs/MessageBroker/Consumer/AzureDevopsConsumer.cs
+++ b/src/AzureDevopsService/AzureDevopsService.Application/Featurs/MessageBroker/Consumer/AzureDevopsConsumer.cs
@@ -2,7 +2,7 @@
 
 public class AzureDevopsConsumer(IMediator mediator, ILogger<AzureDevopsConsumer> logger) :
     IConsumer<AzureAdminInfoRequest>,
-    IConsumer<AllProjectUnderOrganizationRequest>,
+    IConsumer<GetOrganizationProjectsRequest>,
     IConsumer<WorkItemRequest>,
     IConsumer<CreateWebhookRequest>
 {
@@ -16,7 +16,7 @@ public class AzureDevopsConsumer(IMediator mediator, ILogger<AzureDevopsConsumer
         await _mediator.Send(new ProfileUserCommand(context.Message));
     }
 
-    public async Task Consume(ConsumeContext<AllProjectUnderOrganizationRequest> context)
+    public async Task Consume(ConsumeContext<GetOrganizationProjectsRequest> context)
     {
         await _mediator.Send(new ProjectCommand(context.Message));
     }

--- a/src/AzureDevopsService/AzureDevopsService.Application/Featurs/MessageBroker/Producer/ProjectResource/ProjectCommand.cs
+++ b/src/AzureDevopsService/AzureDevopsService.Application/Featurs/MessageBroker/Producer/ProjectResource/ProjectCommand.cs
@@ -1,3 +1,3 @@
 ﻿namespace AzureDevopsService.Application.Featurs.MessageBroker.Producer.ProjectResource;
 
-public record class ProjectCommand(AllProjectUnderOrganizationRequest Request) : IRequest;
+public record class ProjectCommand(GetOrganizationProjectsRequest Request) : IRequest;

--- a/src/AzureDevopsService/AzureDevopsService.Application/Featurs/MessageBroker/Producer/ProjectResource/ProjectCommandHandler.cs
+++ b/src/AzureDevopsService/AzureDevopsService.Application/Featurs/MessageBroker/Producer/ProjectResource/ProjectCommandHandler.cs
@@ -9,10 +9,18 @@ public class ProjectCommandHandler(IProjectService projectService, ISendEndpoint
     {
         ISendEndpoint endpoint = await _sendEndpointProvider.GetSendEndpoint(new Uri("rabbitmq://rabbitmq/ProjectResponce"));
 
-        OneOf<AllProjectResponce, CustomProblemDetailsResponce> projectsResponse = await _projectService.AllProjectUnderOrganization(request.Request);
+        OneOf<OrganizationProjects, CustomProblemDetailsResponce> projectsResponse = await _projectService.AllProjectUnderOrganization(request.Request);
         if (projectsResponse.IsT0)
         {
-            await endpoint.Send(projectsResponse.AsT0, cancellationToken);
+            GetOrganizationProjectsResponse organizationProjectsResponse = new()
+            {
+                Email = request.Request.Email,
+                Path = request.Request.Path,
+                OrganizationId = request.Request.OrganizationId,
+                OrganizationName = request.Request.OrganizationName,
+                OrganizationProjects = projectsResponse.AsT0,
+            };
+            await endpoint.Send(organizationProjectsResponse, cancellationToken);
         }
         else
         {

--- a/src/AzureDevopsService/AzureDevopsService.Contracts/AzureDevopsService.Contracts.csproj
+++ b/src/AzureDevopsService/AzureDevopsService.Contracts/AzureDevopsService.Contracts.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-	<Version>1.0.5</Version>
+	<Version>1.0.6</Version>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/AzureDevopsService/AzureDevopsService.Contracts/AzureRequestResourceModel/AllProjectUnderOrganizationRequest.cs
+++ b/src/AzureDevopsService/AzureDevopsService.Contracts/AzureRequestResourceModel/AllProjectUnderOrganizationRequest.cs
@@ -1,6 +1,0 @@
-﻿namespace AzureDevopsService.Contracts.AzureRequestResourceModel;
-
-public class AllProjectUnderOrganizationRequest : BaseRequest
-{
-    public required string OrganizationName { get; set; }
-}

--- a/src/AzureDevopsService/AzureDevopsService.Contracts/AzureRequestResourceModel/BaseRequest.cs
+++ b/src/AzureDevopsService/AzureDevopsService.Contracts/AzureRequestResourceModel/BaseRequest.cs
@@ -1,6 +1,6 @@
 ﻿namespace AzureDevopsService.Contracts.AzureRequestResourceModel;
 
-public class BaseRequest
+public abstract class BaseRequest
 {
     public string Email { get; set; } = string.Empty;
 

--- a/src/AzureDevopsService/AzureDevopsService.Contracts/AzureResponceModel/OrganizationProjects.cs
+++ b/src/AzureDevopsService/AzureDevopsService.Contracts/AzureResponceModel/OrganizationProjects.cs
@@ -2,7 +2,7 @@
 
 namespace AzureDevopsService.Contracts.AzureResponceModel;
 
-public class AllProjectResponce : BaseRequest
+public class OrganizationProjects
 {
     [property: JsonProperty(PropertyName = "count", NullValueHandling = NullValueHandling.Ignore)]
     public int Count { get; set; }

--- a/src/AzureDevopsService/AzureDevopsService.Contracts/ExternalRequestModel/GetOrganizationProjectsRequest.cs
+++ b/src/AzureDevopsService/AzureDevopsService.Contracts/ExternalRequestModel/GetOrganizationProjectsRequest.cs
@@ -1,0 +1,8 @@
+﻿namespace AzureDevopsService.Contracts.ExternalRequestModel;
+
+public class GetOrganizationProjectsRequest : BaseRequest
+{
+    public required string OrganizationId { get; set; }
+
+    public required string OrganizationName { get; set; }
+}

--- a/src/AzureDevopsService/AzureDevopsService.Contracts/ExternalResponseModel/GetOrganizationProjectsResponse.cs
+++ b/src/AzureDevopsService/AzureDevopsService.Contracts/ExternalResponseModel/GetOrganizationProjectsResponse.cs
@@ -1,0 +1,10 @@
+﻿namespace AzureDevopsService.Contracts.ExternalResponseModel;
+
+public class GetOrganizationProjectsResponse : BaseRequest
+{
+    public required string OrganizationId { get; set; }
+
+    public required string OrganizationName { get; set; }
+
+    public required OrganizationProjects OrganizationProjects { get; set; }
+}

--- a/src/AzureDevopsService/AzureDevopsService.Contracts/Internal/Interface/IProjectService.cs
+++ b/src/AzureDevopsService/AzureDevopsService.Contracts/Internal/Interface/IProjectService.cs
@@ -1,6 +1,8 @@
-﻿namespace AzureDevopsService.Contracts.Internal.Interface;
+﻿using AzureDevopsService.Contracts.ExternalRequestModel;
+
+namespace AzureDevopsService.Contracts.Internal.Interface;
 
 public interface IProjectService
 {
-    Task<OneOf<AllProjectResponce, CustomProblemDetailsResponce>> AllProjectUnderOrganization(AllProjectUnderOrganizationRequest request);
+    Task<OneOf<OrganizationProjects, CustomProblemDetailsResponce>> AllProjectUnderOrganization(GetOrganizationProjectsRequest request);
 }

--- a/src/AzureDevopsService/AzureDevopsService.Infrasructure/AzureDevopsExternalResourceService/ProjectService.cs
+++ b/src/AzureDevopsService/AzureDevopsService.Infrasructure/AzureDevopsExternalResourceService/ProjectService.cs
@@ -1,11 +1,13 @@
-﻿namespace AzureDevopsService.Infrasructure.AzureDevopsExternalResourceService;
+﻿using AzureDevopsService.Contracts.ExternalRequestModel;
+
+namespace AzureDevopsService.Infrasructure.AzureDevopsExternalResourceService;
 
 public class ProjectService(HttpClient httpClient, ILogger<ProjectService> logger) : IProjectService
 {
     private readonly HttpClient _httpClient = httpClient;
     private readonly ILogger<ProjectService> _logger = logger;
 
-    public async Task<OneOf<AllProjectResponce, CustomProblemDetailsResponce>> AllProjectUnderOrganization(AllProjectUnderOrganizationRequest request)
+    public async Task<OneOf<OrganizationProjects, CustomProblemDetailsResponce>> AllProjectUnderOrganization(GetOrganizationProjectsRequest request)
     {
         HttpClientHelper.SetAuthHeader(_httpClient, request.Path);
 
@@ -13,9 +15,7 @@ public class ProjectService(HttpClient httpClient, ILogger<ProjectService> logge
 
         if (projectsResult.StatusCode == HttpStatusCode.OK)
         {
-            AllProjectResponce? projects = await projectsResult.Content.ReadFromJsonAsync<AllProjectResponce>();
-            projects!.Path = request.Path;
-            projects.Email = request.Email;
+            OrganizationProjects? projects = await projectsResult.Content.ReadFromJsonAsync<OrganizationProjects>();
 
             return projects;
         }
@@ -23,8 +23,6 @@ public class ProjectService(HttpClient httpClient, ILogger<ProjectService> logge
         _logger.LogError(await projectsResult.Content.ReadAsStringAsync());
         return new CustomProblemDetailsResponce()
         {
-            Path = request.Path,
-            Email = request.Email,
             Status = (int)projectsResult.StatusCode,
             Detail = AzureResponseMessage.VerifyAzureDevOpsKeyOrOrgName,
         };


### PR DESCRIPTION
This commit replaces the `AllProjectUnderOrganizationRequest` and `AllProjectResponce` classes with new classes `GetOrganizationProjectsRequest` and `OrganizationProjects`.

Key changes include:
- Updated endpoint mappings in `AzureDevopsEndpoints.cs` to use new request/response types.
- Modified consumer implementation in `AzureDevopsConsumer.cs` to handle the new request format.
- Adjusted command handling in `ProjectCommand.cs` and `ProjectCommandHandler.cs` to accommodate the new structures.
- Updated `IProjectService.cs` interface and `ProjectService.cs` implementation to align with the new data models.
- Introduced new classes for better organization of project data.
- Incremented project version from `1.0.5` to `1.0.6`.
- Made `BaseRequest` abstract to enforce inheritance for all requests.
- Removed deprecated request and response classes.