### PR TITLE
Update assembly name and target framework

### DIFF
--- a/src/AzureDevopsService/AzureDevopsService.Contracts/AzureDevopsService.Contracts.csproj
+++ b/src/AzureDevopsService/AzureDevopsService.Contracts/AzureDevopsService.Contracts.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
 	<Version>1.0.6</Version>
+	<AssemblyName>TunNetCom.AionTime.AzureDevopsService.Contracts</AssemblyName>
+	<RootNamespace>TunNetCom.AionTime.AzureDevopsService.Contracts</RootNamespace>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/AzureDevopsService/AzureDevopsService.Contracts/DocumentationFile.xml
+++ b/src/AzureDevopsService/AzureDevopsService.Contracts/DocumentationFile.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <doc>
     <assembly>
-        <name>AzureDevopsService.Contracts</name>
+        <name>TunNetCom.AionTime.AzureDevopsService.Contracts</name>
     </assembly>
     <members>
     </members>


### PR DESCRIPTION
Updated `AzureDevopsService.Contracts.csproj` to set the assembly name and root namespace to `TunNetCom.AionTime.AzureDevopsService.Contracts`, changed the target framework to `net8.0`, and enabled implicit usings. The version remains `1.0.6`. Also updated `DocumentationFile.xml` to reflect the new assembly name.