### PR TITLE
Refactor Azure DevOps API for new request models

### DIFF
--- a/src/AzureDevopsService/AzureDevopsService.API/AzureDevopsEndpoints.cs
+++ b/src/AzureDevopsService/AzureDevopsService.API/AzureDevopsEndpoints.cs
@@ -1,12 +1,16 @@
-﻿namespace AzureDevopsService.API;
+﻿using AzureDevopsService.Contracts.ExternalRequestModel;
+using AzureDevopsService.Contracts.ExternalResponseModel;
+
+namespace AzureDevopsService.API;
 
 public static class AzureDevopsEndpoints
 {
     public static void AddEndpoints(this IEndpointRouteBuilder app)
     {
-        _ = app.MapPost("/GetAdminProfile", async (IUserProfileApiClient externalResourceService, [FromBody] AzureAdminInfoRequest user) =>
+        _ = app.MapPost("/GetAdminProfile", async (IUserProfileApiClient externalResourceService, [FromBody] 
+        GetAzureAdminInfoRequest user) =>
         {
-            OneOf<UserProfile, CustomProblemDetailsResponce> result = await externalResourceService.GetAdminInfo(user);
+            OneOf<UserProfile, CustomProblemDetailsResponce> result = await externalResourceService.GetAdminInfo(user.Path);
             if (result.IsT1)
             {
                 return Results.BadRequest(result.AsT1);
@@ -15,9 +19,9 @@ public static class AzureDevopsEndpoints
             return Results.Ok(result.AsT0);
         });
 
-        _ = app.MapPost("/{userId}/GetUserOrganization", async (string userId, IUserProfileApiClient externalResourceService, [FromBody] GetUserOrganizationRequest request) =>
+        _ = app.MapPost("/{userId}/GetUserOrganization", async (string userId, string path, IUserProfileApiClient externalResourceService) =>
         {
-            OneOf<UserAccount, CustomProblemDetailsResponce> result = await externalResourceService.GeUserOrganizations(request);
+            OneOf<UserAccountOrganization, CustomProblemDetailsResponce> result = await externalResourceService.GeUserOrganizations(userId, path);
             if (result.IsT1)
             {
                 return Results.BadRequest(result.AsT1);
@@ -40,7 +44,7 @@ public static class AzureDevopsEndpoints
 
         _ = app.MapPost("/ProjectByOrganization", async (IProjectService workItemExternalService, GetOrganizationProjectsRequest request) =>
         {
-            OneOf<OrganizationProjects, CustomProblemDetailsResponce> result = await workItemExternalService.AllProjectUnderOrganization(request);
+            OneOf<OrganizationProjects, CustomProblemDetailsResponce> result = await workItemExternalService.AllProjectUnderOrganization(request.OrganizationName, request.Path);
 
             if (result.IsT1)
             {
@@ -50,11 +54,11 @@ public static class AzureDevopsEndpoints
             return Results.Ok(result.AsT0);
         });
 
-        _ = app.MapPost("/CreateWebhook", async (IMediator _mediator, CreateWebhookRequest request) =>
-        {
-            Contracts.ExternalResponseModel.WebhookCreatedResponse response = await _mediator.Send(new CreateWebhookCommand(request));
+        // _ = app.MapPost("/CreateWebhook", async (IMediator _mediator, CreateWebhookRequest request) =>
+        // {
+        //    WebhookCreatedResponse response = await _mediator.Send(new CreateWebhookCommand(request));
 
-            return Results.Ok(response);
-        });
+        // return Results.Ok(response);
+        // });
     }
 }

--- a/src/AzureDevopsService/AzureDevopsService.API/GlobalUsings.cs
+++ b/src/AzureDevopsService/AzureDevopsService.API/GlobalUsings.cs
@@ -1,7 +1,6 @@
 ﻿global using AzureDevopsService.API;
 global using AzureDevopsService.Application;
 global using AzureDevopsService.Application.Featurs.MessageBroker.Producer.Webhook;
-global using AzureDevopsService.Contracts.AzureRequestModel;
 global using AzureDevopsService.Contracts.AzureRequestResourceModel;
 global using AzureDevopsService.Contracts.AzureResponceModel;
 global using AzureDevopsService.Contracts.AzureResponceModel.BadRequest;

--- a/src/AzureDevopsService/AzureDevopsService.Application/Featurs/MessageBroker/Consumer/AzureDevopsConsumer.cs
+++ b/src/AzureDevopsService/AzureDevopsService.Application/Featurs/MessageBroker/Consumer/AzureDevopsConsumer.cs
@@ -1,7 +1,9 @@
-﻿namespace AzureDevopsService.Application.Featurs.MessageBroker.Consumer;
+﻿using AzureDevopsService.Contracts.ExternalRequestModel;
+
+namespace AzureDevopsService.Application.Featurs.MessageBroker.Consumer;
 
 public class AzureDevopsConsumer(IMediator mediator, ILogger<AzureDevopsConsumer> logger) :
-    IConsumer<AzureAdminInfoRequest>,
+    IConsumer<GetAzureAdminInfoRequest>,
     IConsumer<GetOrganizationProjectsRequest>,
     IConsumer<WorkItemRequest>,
     IConsumer<CreateWebhookRequest>
@@ -9,7 +11,7 @@ public class AzureDevopsConsumer(IMediator mediator, ILogger<AzureDevopsConsumer
     private readonly IMediator _mediator = mediator;
     private readonly ILogger<AzureDevopsConsumer> _logger = logger;
 
-    public async Task Consume(ConsumeContext<AzureAdminInfoRequest> context)
+    public async Task Consume(ConsumeContext<GetAzureAdminInfoRequest> context)
     {
         _logger.LogInformation("ProfileUserCommandHandler triggered with request: {context}", context);
 

--- a/src/AzureDevopsService/AzureDevopsService.Application/Featurs/MessageBroker/Producer/Helper/EventCreationHelper.cs
+++ b/src/AzureDevopsService/AzureDevopsService.Application/Featurs/MessageBroker/Producer/Helper/EventCreationHelper.cs
@@ -34,11 +34,9 @@ public static class EventCreationHelper
                         {
                             HttpHeaders = WebhookSettings.HttpHeaders,
                             ResourceDetailsToSend = WebhookSettings.ResourceDetailsToSend,
-                            Url = string.Format(WebhookSettings.BaseUrl, WebhookEndpoint.AzureWorkItemsEvents, organization.OrganizationId),
+                            Url = string.Format(WebhookSettings.BaseUrl, WebhookEndpoint.AzureWorkItemsEvents, organization.OrganizationId, request.TenantId),
                         },
                         EventType = eventType,
-                        OrganizationName = organization.OrganizationName,
-                        Path = request.Path,
                         PublisherId = WebhookSettings.PublisherId,
                         PublisherInputs = new()
                         {
@@ -71,11 +69,9 @@ public static class EventCreationHelper
                         {
                             HttpHeaders = WebhookSettings.HttpHeaders,
                             ResourceDetailsToSend = WebhookSettings.ResourceDetailsToSend,
-                            Url = string.Format(WebhookSettings.BaseUrl, WebhookEndpoint.BuildAndReleaseEvents, organization.OrganizationId),
+                            Url = string.Format(WebhookSettings.BaseUrl, WebhookEndpoint.BuildAndReleaseEvents, organization.OrganizationId, request.TenantId),
                         },
                         EventType = eventType,
-                        OrganizationName = organization.OrganizationName,
-                        Path = request.Path,
                         PublisherId = WebhookSettings.PublisherId,
                         PublisherInputs = new()
                         {
@@ -108,11 +104,9 @@ public static class EventCreationHelper
                         {
                             HttpHeaders = WebhookSettings.HttpHeaders,
                             ResourceDetailsToSend = WebhookSettings.ResourceDetailsToSend,
-                            Url = string.Format(WebhookSettings.BaseUrl, WebhookEndpoint.BuildAndReleaseEvents, organization.OrganizationId),
+                            Url = string.Format(WebhookSettings.BaseUrl, WebhookEndpoint.BuildAndReleaseEvents, organization.OrganizationId, request.TenantId),
                         },
                         EventType = eventType,
-                        OrganizationName = organization.OrganizationName,
-                        Path = request.Path,
                         PublisherId = WebhookSettings.PublisherId,
                         PublisherInputs = new()
                         {
@@ -145,11 +139,9 @@ public static class EventCreationHelper
                         {
                             HttpHeaders = WebhookSettings.HttpHeaders,
                             ResourceDetailsToSend = WebhookSettings.ResourceDetailsToSend,
-                            Url = string.Format(WebhookSettings.BaseUrl, WebhookEndpoint.AzureCodeEvents, organization.OrganizationId),
+                            Url = string.Format(WebhookSettings.BaseUrl, WebhookEndpoint.AzureCodeEvents, organization.OrganizationId, request.TenantId),
                         },
                         EventType = eventType,
-                        OrganizationName = organization.OrganizationName,
-                        Path = request.Path,
                         PublisherId = WebhookSettings.PublisherId,
                         PublisherInputs = new()
                         {

--- a/src/AzureDevopsService/AzureDevopsService.Application/Featurs/MessageBroker/Producer/ProfileUser/ProfileUserCommand.cs
+++ b/src/AzureDevopsService/AzureDevopsService.Application/Featurs/MessageBroker/Producer/ProfileUser/ProfileUserCommand.cs
@@ -1,3 +1,5 @@
-﻿namespace AzureDevopsService.Application.Featurs.MessageBroker.Producer.ProfileUser;
+﻿using AzureDevopsService.Contracts.ExternalRequestModel;
 
-public record class ProfileUserCommand(AzureAdminInfoRequest Request) : IRequest;
+namespace AzureDevopsService.Application.Featurs.MessageBroker.Producer.ProfileUser;
+
+public record class ProfileUserCommand(GetAzureAdminInfoRequest Request) : IRequest;

--- a/src/AzureDevopsService/AzureDevopsService.Application/Featurs/MessageBroker/Producer/ProjectResource/ProjectCommandHandler.cs
+++ b/src/AzureDevopsService/AzureDevopsService.Application/Featurs/MessageBroker/Producer/ProjectResource/ProjectCommandHandler.cs
@@ -9,13 +9,14 @@ public class ProjectCommandHandler(IProjectService projectService, ISendEndpoint
     {
         ISendEndpoint endpoint = await _sendEndpointProvider.GetSendEndpoint(new Uri("rabbitmq://rabbitmq/ProjectResponce"));
 
-        OneOf<OrganizationProjects, CustomProblemDetailsResponce> projectsResponse = await _projectService.AllProjectUnderOrganization(request.Request);
+        OneOf<OrganizationProjects, CustomProblemDetailsResponce> projectsResponse = await _projectService.AllProjectUnderOrganization(request.Request.OrganizationName, request.Request.Path);
         if (projectsResponse.IsT0)
         {
             GetOrganizationProjectsResponse organizationProjectsResponse = new()
             {
                 Email = request.Request.Email,
                 Path = request.Request.Path,
+                TenantId = request.Request.TenantId,
                 OrganizationId = request.Request.OrganizationId,
                 OrganizationName = request.Request.OrganizationName,
                 OrganizationProjects = projectsResponse.AsT0,

--- a/src/AzureDevopsService/AzureDevopsService.Application/Featurs/MessageBroker/Producer/Webhook/CreateWebhookCommanHandler.cs
+++ b/src/AzureDevopsService/AzureDevopsService.Application/Featurs/MessageBroker/Producer/Webhook/CreateWebhookCommanHandler.cs
@@ -8,7 +8,12 @@ public class CreateWebhookCommanHandler(IWebhookService webhookService, IPublish
     public async Task<WebhookCreatedResponse> Handle(CreateWebhookCommand request, CancellationToken cancellationToken)
     {
         List<ServiceHookReques> allRequest = EventCreationHelper.PrepareAllWbhookEventRequest(request.Request);
-        WebhookCreatedResponse createdWebhook = new() { Email = request.Request.Email, Path = request.Request.Path };
+        WebhookCreatedResponse createdWebhook = new()
+        {
+            Email = request.Request.Email,
+            Path = request.Request.Path,
+            TenantId = request.Request.TenantId,
+        };
         foreach (ServiceHookReques serviecHookRequestMessage in allRequest)
         {
             OneOf<WebhookResponce, WebhookBadRequestResponce> webhookResponse = await _webhookService.CreateWebhookSubscription(serviecHookRequestMessage);

--- a/src/AzureDevopsService/AzureDevopsService.Application/GlobalUsings.cs
+++ b/src/AzureDevopsService/AzureDevopsService.Application/GlobalUsings.cs
@@ -5,7 +5,6 @@ global using AzureDevopsService.Application.Featurs.MessageBroker.Producer.Profi
 global using AzureDevopsService.Application.Featurs.MessageBroker.Producer.ProjectResource;
 global using AzureDevopsService.Application.Featurs.MessageBroker.Producer.Webhook;
 global using AzureDevopsService.Application.Featurs.MessageBroker.Producer.WorkItemResource;
-global using AzureDevopsService.Contracts.AzureRequestModel;
 global using AzureDevopsService.Contracts.AzureRequestResourceModel;
 global using AzureDevopsService.Contracts.AzureResponceModel;
 global using AzureDevopsService.Contracts.AzureResponceModel.BadRequest;

--- a/src/AzureDevopsService/AzureDevopsService.Contracts/AzureDevopsService.Contracts.csproj
+++ b/src/AzureDevopsService/AzureDevopsService.Contracts/AzureDevopsService.Contracts.csproj
@@ -3,9 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-	<Version>1.0.6</Version>
-	<AssemblyName>TunNetCom.AionTime.AzureDevopsService.Contracts</AssemblyName>
-	<RootNamespace>TunNetCom.AionTime.AzureDevopsService.Contracts</RootNamespace>
+	<Version>1.0.7</Version>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/AzureDevopsService/AzureDevopsService.Contracts/AzureRequestModel/AzureAdminInfoRequest.cs
+++ b/src/AzureDevopsService/AzureDevopsService.Contracts/AzureRequestModel/AzureAdminInfoRequest.cs
@@ -1,8 +1,0 @@
-﻿namespace AzureDevopsService.Contracts.AzureRequestModel;
-
-public class AzureAdminInfoRequest
-{
-    public string Email { get; set; } = string.Empty;
-
-    public string Path { get; set; } = string.Empty;
-}

--- a/src/AzureDevopsService/AzureDevopsService.Contracts/AzureRequestResourceModel/BaseRequest.cs
+++ b/src/AzureDevopsService/AzureDevopsService.Contracts/AzureRequestResourceModel/BaseRequest.cs
@@ -5,4 +5,6 @@ public abstract class BaseRequest
     public string Email { get; set; } = string.Empty;
 
     public string Path { get; set; } = string.Empty;
+
+    public required string TenantId { get; set; }
 }

--- a/src/AzureDevopsService/AzureDevopsService.Contracts/AzureResponceModel/AzureOrganizationValue.cs
+++ b/src/AzureDevopsService/AzureDevopsService.Contracts/AzureResponceModel/AzureOrganizationValue.cs
@@ -1,6 +1,6 @@
 ﻿namespace AzureDevopsService.Contracts.AzureResponceModel;
 
-public class UserOrganization
+public class AzureOrganizationValue
 {
     [JsonProperty("accountId")]
     public string AccountId { get; set; } = string.Empty;

--- a/src/AzureDevopsService/AzureDevopsService.Contracts/AzureResponceModel/UserAccountOrganization.cs
+++ b/src/AzureDevopsService/AzureDevopsService.Contracts/AzureResponceModel/UserAccountOrganization.cs
@@ -1,10 +1,10 @@
 ﻿namespace AzureDevopsService.Contracts.AzureResponceModel;
 
-public class UserAccount : BaseRequest
+public class UserAccountOrganization
 {
     [property: JsonProperty(PropertyName = "count", NullValueHandling = NullValueHandling.Ignore)]
     public int Count { get; set; }
 
     [property: JsonProperty(PropertyName = "value", NullValueHandling = NullValueHandling.Ignore)]
-    public IEnumerable<UserOrganization> Value { get; set; } = Enumerable.Empty<UserOrganization>();
+    public IEnumerable<AzureOrganizationValue> Value { get; set; } = Enumerable.Empty<AzureOrganizationValue>();
 }

--- a/src/AzureDevopsService/AzureDevopsService.Contracts/AzureResponceModel/UserProfile.cs
+++ b/src/AzureDevopsService/AzureDevopsService.Contracts/AzureResponceModel/UserProfile.cs
@@ -1,6 +1,6 @@
 ﻿namespace AzureDevopsService.Contracts.AzureResponceModel;
 
-public class UserProfile : BaseRequest
+public class UserProfile
 {
     [JsonProperty("displayName")]
     public string DisplayName { get; set; } = string.Empty;
@@ -22,7 +22,4 @@ public class UserProfile : BaseRequest
 
     [JsonProperty("revision")]
     public int Revision { get; set; }
-
-    [JsonProperty("UserAccount")]
-    public UserAccount? UserAccount { get; set; }
 }

--- a/src/AzureDevopsService/AzureDevopsService.Contracts/Constant/WebhookEndpoint.cs
+++ b/src/AzureDevopsService/AzureDevopsService.Contracts/Constant/WebhookEndpoint.cs
@@ -1,17 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace AzureDevopsService.Contracts.Constant;
 
-namespace AzureDevopsService.Contracts.Constant
+public static class WebhookEndpoint
 {
-    public static class WebhookEndpoint
-    {
-        public const string AzureWorkItemsEvents = "AzureWorkItemsEvents";
+    public const string AzureWorkItemsEvents = "AzureWorkItemsEvents";
 
-        public const string BuildAndReleaseEvents = "BuildAndReleaseEvents";
+    public const string BuildAndReleaseEvents = "BuildAndReleaseEvents";
 
-        public const string AzureCodeEvents = "AzureCodeEvents";
-    }
+    public const string AzureCodeEvents = "AzureCodeEvents";
 }

--- a/src/AzureDevopsService/AzureDevopsService.Contracts/Constant/WebhookSettings.cs
+++ b/src/AzureDevopsService/AzureDevopsService.Contracts/Constant/WebhookSettings.cs
@@ -1,12 +1,11 @@
-﻿namespace AzureDevopsService.Contracts.Constant
+﻿namespace AzureDevopsService.Contracts.Constant;
+
+public static class WebhookSettings
 {
-    public static class WebhookSettings
-    {
-        public const string BaseUrl = "https://your-public-api.com/{0}?organizationId={1}";
-        public const string HttpHeaders = "{\"Content-Type\": \"application/json\"}";
-        public const string ResourceDetailsToSend = "all";
-        public const string PublisherId = "tfs";
-        public const string ConsumerId = "webHooks";
-        public const string ConsumerActionId = "httpRequest";
-    }
+    public const string BaseUrl = "https://your-public-api.com/{0}?organizationId={1}&TenantId={2}";
+    public const string HttpHeaders = "{\"Content-Type\": \"application/json\"}";
+    public const string ResourceDetailsToSend = "all";
+    public const string PublisherId = "tfs";
+    public const string ConsumerId = "webHooks";
+    public const string ConsumerActionId = "httpRequest";
 }

--- a/src/AzureDevopsService/AzureDevopsService.Contracts/DocumentationFile.xml
+++ b/src/AzureDevopsService/AzureDevopsService.Contracts/DocumentationFile.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <doc>
     <assembly>
-        <name>TunNetCom.AionTime.AzureDevopsService.Contracts</name>
+        <name>AzureDevopsService.Contracts</name>
     </assembly>
     <members>
     </members>

--- a/src/AzureDevopsService/AzureDevopsService.Contracts/ExternalRequestModel/CreateWebhookRequest.cs
+++ b/src/AzureDevopsService/AzureDevopsService.Contracts/ExternalRequestModel/CreateWebhookRequest.cs
@@ -2,5 +2,5 @@
 
 public class CreateWebhookRequest : BaseRequest
 {
-    public List<Organization> Organizations {  get; set; }
+    public List<Organization> Organizations { get; set; } = [];
 }

--- a/src/AzureDevopsService/AzureDevopsService.Contracts/ExternalRequestModel/GetAzureAdminInfoRequest.cs
+++ b/src/AzureDevopsService/AzureDevopsService.Contracts/ExternalRequestModel/GetAzureAdminInfoRequest.cs
@@ -1,0 +1,5 @@
+﻿namespace AzureDevopsService.Contracts.ExternalRequestModel;
+
+public class GetAzureAdminInfoRequest : BaseRequest
+{
+}

--- a/src/AzureDevopsService/AzureDevopsService.Contracts/ExternalResponseModel/GetAzureAdminInfoResponse.cs
+++ b/src/AzureDevopsService/AzureDevopsService.Contracts/ExternalResponseModel/GetAzureAdminInfoResponse.cs
@@ -1,0 +1,8 @@
+﻿namespace AzureDevopsService.Contracts.ExternalResponseModel;
+
+public class GetAzureAdminInfoResponse : BaseRequest
+{
+    public required UserProfile UserProfile { get; set; }
+
+    public UserAccountOrganization? UserOrganization { get; set; }
+}

--- a/src/AzureDevopsService/AzureDevopsService.Contracts/GlobalUsings.cs
+++ b/src/AzureDevopsService/AzureDevopsService.Contracts/GlobalUsings.cs
@@ -1,5 +1,4 @@
-﻿global using AzureDevopsService.Contracts.AzureRequestModel;
-global using AzureDevopsService.Contracts.AzureRequestResourceModel;
+﻿global using AzureDevopsService.Contracts.AzureRequestResourceModel;
 global using AzureDevopsService.Contracts.AzureResponceModel;
 global using AzureDevopsService.Contracts.AzureResponceModel.BadRequest;
 global using AzureDevopsService.Contracts.AzureResponceModel.SuccessResponce;

--- a/src/AzureDevopsService/AzureDevopsService.Contracts/Internal/Interface/IProjectService.cs
+++ b/src/AzureDevopsService/AzureDevopsService.Contracts/Internal/Interface/IProjectService.cs
@@ -1,8 +1,6 @@
-﻿using AzureDevopsService.Contracts.ExternalRequestModel;
-
-namespace AzureDevopsService.Contracts.Internal.Interface;
+﻿namespace AzureDevopsService.Contracts.Internal.Interface;
 
 public interface IProjectService
 {
-    Task<OneOf<OrganizationProjects, CustomProblemDetailsResponce>> AllProjectUnderOrganization(GetOrganizationProjectsRequest request);
+    Task<OneOf<OrganizationProjects, CustomProblemDetailsResponce>> AllProjectUnderOrganization(string organizationName, string path);
 }

--- a/src/AzureDevopsService/AzureDevopsService.Contracts/Internal/Interface/IUserProfileApiClient.cs
+++ b/src/AzureDevopsService/AzureDevopsService.Contracts/Internal/Interface/IUserProfileApiClient.cs
@@ -2,7 +2,7 @@
 
 public interface IUserProfileApiClient
 {
-    Task<OneOf<UserProfile, CustomProblemDetailsResponce>> GetAdminInfo(AzureAdminInfoRequest request);
+    Task<OneOf<UserProfile, CustomProblemDetailsResponce>> GetAdminInfo(string path);
 
-    Task<OneOf<UserAccount, CustomProblemDetailsResponce>> GeUserOrganizations(GetUserOrganizationRequest request);
+    Task<OneOf<UserAccountOrganization, CustomProblemDetailsResponce>> GeUserOrganizations(string memberId, string path);
 }

--- a/src/AzureDevopsService/AzureDevopsService.Infrasructure/AzureDevopsExternalResourceService/ProjectService.cs
+++ b/src/AzureDevopsService/AzureDevopsService.Infrasructure/AzureDevopsExternalResourceService/ProjectService.cs
@@ -1,17 +1,15 @@
-﻿using AzureDevopsService.Contracts.ExternalRequestModel;
-
-namespace AzureDevopsService.Infrasructure.AzureDevopsExternalResourceService;
+﻿namespace AzureDevopsService.Infrasructure.AzureDevopsExternalResourceService;
 
 public class ProjectService(HttpClient httpClient, ILogger<ProjectService> logger) : IProjectService
 {
     private readonly HttpClient _httpClient = httpClient;
     private readonly ILogger<ProjectService> _logger = logger;
 
-    public async Task<OneOf<OrganizationProjects, CustomProblemDetailsResponce>> AllProjectUnderOrganization(GetOrganizationProjectsRequest request)
+    public async Task<OneOf<OrganizationProjects, CustomProblemDetailsResponce>> AllProjectUnderOrganization(string organizationName, string path)
     {
-        HttpClientHelper.SetAuthHeader(_httpClient, request.Path);
+        HttpClientHelper.SetAuthHeader(_httpClient, path);
 
-        HttpResponseMessage projectsResult = await _httpClient.GetAsync($"{request.OrganizationName}{AzureUrlsEndPoint.Projects}");
+        HttpResponseMessage projectsResult = await _httpClient.GetAsync($"{organizationName}{AzureUrlsEndPoint.Projects}");
 
         if (projectsResult.StatusCode == HttpStatusCode.OK)
         {

--- a/src/AzureDevopsService/AzureDevopsService.Infrasructure/AzureDevopsExternalResourceService/ServiceHelper/WorkItem/WorkItemHelper.cs
+++ b/src/AzureDevopsService/AzureDevopsService.Infrasructure/AzureDevopsExternalResourceService/ServiceHelper/WorkItem/WorkItemHelper.cs
@@ -6,6 +6,7 @@ public static class WorkItemHelper
     {
         return new()
         {
+            TenantId = resource.TenantId,
             ApiVersion = "v5",
             Organization = resource.OrganisationName,
             Project = resource.ProjectName,
@@ -13,6 +14,19 @@ public static class WorkItemHelper
             Query = $@"SELECT [System.Id], [System.Title], [System.State], [System.IterationPath] 
                     FROM workitems WHERE [System.TeamProject] = @project AND [System.WorkItemType] <> '' 
                     AND EVER [System.AssignedTo] = '{resource.Email}'",
+        };
+    }
+
+    public static WiqlRequest FillGetWorkItemsIdsUnderProject(WorkItemRequest resource)
+    {
+        return new()
+        {
+            TenantId = resource.TenantId,
+            ApiVersion = "v5",
+            Organization = resource.OrganisationName,
+            Project = resource.ProjectName,
+            Team = "938eb754-ae25-4088-bf34-c9bf242e966c",
+            Query = $@"SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = 'YourProjectName'",
         };
     }
 }

--- a/src/AzureDevopsService/AzureDevopsService.Infrasructure/AzureDevopsExternalResourceService/WorkItemExternalService.cs
+++ b/src/AzureDevopsService/AzureDevopsService.Infrasructure/AzureDevopsExternalResourceService/WorkItemExternalService.cs
@@ -37,6 +37,7 @@ public class WorkItemExternalService(HttpClient httpClient, ILogger<WorkItemExte
         return new WiqlBadRequestResponce()
         {
             Email = resource.Email,
+            TenantId = resource.TenantId,
             ErrorCode = (int)workItemResponse.StatusCode,
             Message = AzureResponseMessage.WorkItemError,
             Path = resource.Path,

--- a/src/AzureDevopsService/AzureDevopsService.Infrasructure/AzureDevopsService.Infrasructure.csproj
+++ b/src/AzureDevopsService/AzureDevopsService.Infrasructure/AzureDevopsService.Infrasructure.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
+	<id>TunNetCom.AionTime.AzureDevopsService.Contracts</id>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 	

--- a/src/AzureDevopsService/AzureDevopsService.Infrasructure/GlobalUsings.cs
+++ b/src/AzureDevopsService/AzureDevopsService.Infrasructure/GlobalUsings.cs
@@ -1,5 +1,4 @@
-﻿global using AzureDevopsService.Contracts.AzureRequestModel;
-global using AzureDevopsService.Contracts.AzureRequestResourceModel;
+﻿global using AzureDevopsService.Contracts.AzureRequestResourceModel;
 global using AzureDevopsService.Contracts.AzureResponceModel;
 global using AzureDevopsService.Contracts.AzureResponceModel.BadRequest;
 global using AzureDevopsService.Contracts.AzureResponceModel.SuccessResponce;


### PR DESCRIPTION
Updated the Azure DevOps service API to transition from `AzureAdminInfoRequest` to `GetAzureAdminInfoRequest`, enhancing request handling with new response models. Modified namespaces to include new contracts for external requests and responses, and consistently updated the `Path` property across classes.

The `WebhookSettings` class now includes a `TenantId` in the base URL, and the `UserProfile` class has been simplified by removing inheritance from `BaseRequest`. New classes such as `GetAzureAdminInfoRequest`, `GetAzureAdminInfoResponse`, and `UserAccountOrganization` have been introduced for better data encapsulation.

Incremented project version from `1.0.6` to `1.0.7`, and improved code structure by removing unnecessary comments. Enhanced handling of user organizations and projects to support more specific parameters in API requests.