### PR TITLE
Add project ID to AzureDevopsService.Contracts.csproj

### DIFF
--- a/src/AzureDevopsService/AzureDevopsService.Contracts/AzureDevopsService.Contracts.csproj
+++ b/src/AzureDevopsService/AzureDevopsService.Contracts/AzureDevopsService.Contracts.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
 	<Version>1.0.7</Version>
+	<id>TunNetCom.AionTime.AzureDevopsService.Contracts</id>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
Added an `<id>` element with the value `TunNetCom.AionTime.AzureDevopsService.Contracts` to the project file. This change helps uniquely identify the project within a larger solution or system.