### PR TITLE
Integrate RabbitMQ for event handling

### DIFF
--- a/src/TimeLogService/TimeLogService.Application/ApplicationServiceRegistration.cs
+++ b/src/TimeLogService/TimeLogService.Application/ApplicationServiceRegistration.cs
@@ -1,5 +1,6 @@
 ﻿using TimeLogService.Application.Events.IntegrationEvents;
 using TimeLogService.Application.Events.IntegrationEvents.EventsHandlers;
+using TunNetCom.AionTime.SharedKernel;
 
 namespace TimeLogService.Application
 {
@@ -9,6 +10,20 @@ namespace TimeLogService.Application
         {
             _ = services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblies(Assembly.GetExecutingAssembly()));
             _ = services.AddAutoMapper(Assembly.GetExecutingAssembly());
+
+            _ = services.AddRabbitMQ(
+                config =>
+                {
+                    config.EventBusConnection = "localhost";
+                    config.EventBusUserName = "AionTime";
+                    config.EventBusPassword = "AionTime";
+                    config.ServiceName = "timelog_service";
+                    config.EventBusRetryCount = 5;
+                },
+                eventBus =>
+                {
+                    eventBus.Subscribe<TenantOrganizationProjectsRetrivedIntegrationEvent, TenantOrganizationProjectsRetrivedIntegrationEventHandler>();
+                });
 
             return services;
         }

--- a/src/TunNetCom.AionTime.SharedKernel/TunNetCom.AionTime.SharedKernel/EventBus/Abstractions/IDynamicIntegrationEventHandler.cs
+++ b/src/TunNetCom.AionTime.SharedKernel/TunNetCom.AionTime.SharedKernel/EventBus/Abstractions/IDynamicIntegrationEventHandler.cs
@@ -1,0 +1,8 @@
+﻿using TunNetCom.AionTime.SharedKernel.EventBus.Abstractions;
+
+namespace TunNetCom.AionTime.SharedKernel.EventBus.Abstractions;
+
+public interface IDynamicIntegrationEventHandler
+{
+    Task Handle(dynamic eventData);
+}

--- a/src/TunNetCom.AionTime.SharedKernel/TunNetCom.AionTime.SharedKernel/EventBus/Abstractions/IEventBus.cs
+++ b/src/TunNetCom.AionTime.SharedKernel/TunNetCom.AionTime.SharedKernel/EventBus/Abstractions/IEventBus.cs
@@ -3,4 +3,18 @@
 public interface IEventBus
 {
     Task PublishAsync(IntegrationEvent @integrationEvent);
+
+    void Subscribe<T, TH>()
+     where T : IntegrationEvent
+     where TH : IIntegrationEventHandler<T>;
+
+    void SubscribeDynamic<TH>(string eventName)
+        where TH : IDynamicIntegrationEventHandler;
+
+    void UnsubscribeDynamic<TH>(string eventName)
+        where TH : IDynamicIntegrationEventHandler;
+
+    void Unsubscribe<T, TH>()
+        where TH : IIntegrationEventHandler<T>
+        where T : IntegrationEvent;
 }

--- a/src/TunNetCom.AionTime.SharedKernel/TunNetCom.AionTime.SharedKernel/EventBusRabbitMQ/DefaultRabbitMQPersistentConnection.cs
+++ b/src/TunNetCom.AionTime.SharedKernel/TunNetCom.AionTime.SharedKernel/EventBusRabbitMQ/DefaultRabbitMQPersistentConnection.cs
@@ -1,0 +1,124 @@
+﻿using TunNetCom.AionTime.SharedKernel.EventBusRabbitMQ;
+
+namespace TunNetCom.AionTime.SharedKernel.EventBusRabbitMQ;
+
+public class DefaultRabbitMQPersistentConnection(
+    IConnectionFactory connectionFactory,
+    ILogger<DefaultRabbitMQPersistentConnection> logger,
+    int retryCount = 5) : IRabbitMQPersistentConnection
+{
+    private readonly IConnectionFactory _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+    private readonly ILogger<DefaultRabbitMQPersistentConnection> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    private readonly int _retryCount = retryCount;
+    private readonly object _syncRoot = new();
+    private IConnection _connection;
+    private bool _disposed;
+
+    public bool IsConnected => _connection is { IsOpen: true } && !_disposed;
+
+    public IModel CreateModel()
+    {
+        if (!IsConnected)
+        {
+            throw new InvalidOperationException("No RabbitMQ connections are available to perform this action");
+        }
+
+        return _connection.CreateModel();
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        try
+        {
+            _connection.ConnectionShutdown -= OnConnectionShutdown;
+            _connection.CallbackException -= OnCallbackException;
+            _connection.ConnectionBlocked -= OnConnectionBlocked;
+            _connection.Dispose();
+        }
+        catch (IOException ex)
+        {
+            _logger.LogCritical(ex.ToString());
+        }
+    }
+
+    public bool TryConnect()
+    {
+        _logger.LogInformation("RabbitMQ Client is trying to connect");
+
+        lock (_syncRoot)
+        {
+            RetryPolicy policy = Policy.Handle<SocketException>()
+                .Or<BrokerUnreachableException>()
+                .WaitAndRetry(_retryCount, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)), (ex, time) =>
+                {
+                    _logger.LogWarning(ex, "RabbitMQ Client could not connect after {TimeOut}s ({ExceptionMessage})", $"{time.TotalSeconds:n1}", ex.Message);
+                });
+
+            policy.Execute(() =>
+            {
+                _connection = _connectionFactory
+                        .CreateConnection();
+            });
+
+            if (IsConnected)
+            {
+                _connection.ConnectionShutdown += OnConnectionShutdown;
+                _connection.CallbackException += OnCallbackException;
+                _connection.ConnectionBlocked += OnConnectionBlocked;
+
+                _logger.LogInformation("RabbitMQ Client acquired a persistent connection to '{HostName}' and is subscribed to failure events", _connection.Endpoint.HostName);
+
+                return true;
+            }
+            else
+            {
+                _logger.LogCritical("FATAL ERROR: RabbitMQ connections could not be created and opened");
+
+                return false;
+            }
+        }
+    }
+
+    private void OnConnectionBlocked(object sender, ConnectionBlockedEventArgs e)
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _logger.LogWarning("A RabbitMQ connection is shutdown. Trying to re-connect...");
+
+        _ = TryConnect();
+    }
+
+    private void OnCallbackException(object sender, CallbackExceptionEventArgs e)
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _logger.LogWarning("A RabbitMQ connection throw exception. Trying to re-connect...");
+
+        _ = TryConnect();
+    }
+
+    private void OnConnectionShutdown(object sender, ShutdownEventArgs reason)
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _logger.LogWarning("A RabbitMQ connection is on shutdown. Trying to re-connect...");
+
+        _ = TryConnect();
+    }
+}

--- a/src/TunNetCom.AionTime.SharedKernel/TunNetCom.AionTime.SharedKernel/EventBusRabbitMQ/EventBusRabbitMQService.cs
+++ b/src/TunNetCom.AionTime.SharedKernel/TunNetCom.AionTime.SharedKernel/EventBusRabbitMQ/EventBusRabbitMQService.cs
@@ -1,0 +1,286 @@
+﻿namespace TunNetCom.AionTime.SharedKernel.EventBusRabbitMQ;
+
+public class EventBusRabbitMQService : IEventBus, IDisposable
+{
+    private const string BROKER_NAME = "aion_time_event_bus";
+    private const string AUTOFAC_SCOPE_NAME = "aion_time_event_bus";
+
+    private readonly IRabbitMQPersistentConnection _persistentConnection;
+    private readonly ILogger<EventBusRabbitMQService> _logger;
+    private readonly IEventBusSubscriptionsManager _subsManager;
+    private readonly ILifetimeScope _autofac;
+    private readonly int _retryCount;
+
+    private IModel _consumerChannel;
+    private string _queueName;
+
+    public EventBusRabbitMQService(
+        IRabbitMQPersistentConnection persistentConnection,
+        ILogger<EventBusRabbitMQService> logger,
+        ILifetimeScope autofac,
+        IEventBusSubscriptionsManager subsManager,
+        string queueName = null,
+        int retryCount = 5)
+    {
+        _persistentConnection = persistentConnection ?? throw new ArgumentNullException(nameof(persistentConnection));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _subsManager = subsManager ?? new InMemoryEventBusSubscriptionsManager();
+        _queueName = queueName;
+        _consumerChannel = CreateConsumerChannel();
+        _autofac = autofac;
+        _retryCount = retryCount;
+        _subsManager.OnEventRemoved += SubsManager_OnEventRemoved;
+    }
+
+    private void SubsManager_OnEventRemoved(object? sender, string eventName)
+    {
+        if (!_persistentConnection.IsConnected)
+        {
+            _ = _persistentConnection.TryConnect();
+        }
+
+        using IModel channel = _persistentConnection.CreateModel();
+        channel.QueueUnbind(
+            queue: _queueName,
+            exchange: BROKER_NAME,
+            routingKey: eventName);
+
+        if (_subsManager.IsEmpty)
+        {
+            _queueName = string.Empty;
+            _consumerChannel.Close();
+        }
+    }
+
+    public Task PublishAsync(IntegrationEvent @event)
+    {
+        if (!_persistentConnection.IsConnected)
+        {
+            _ = _persistentConnection.TryConnect();
+        }
+
+        RetryPolicy policy = Policy.Handle<BrokerUnreachableException>()
+            .Or<SocketException>()
+            .WaitAndRetry(_retryCount, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)), (ex, time) =>
+            {
+                _logger.LogWarning(ex, "Could not publish event: {EventId} after {Timeout}s ({ExceptionMessage})", @event.Id, $"{time.TotalSeconds:n1}", ex.Message);
+            });
+
+        string eventName = @event.GetType().Name;
+
+        _logger.LogTrace("Creating RabbitMQ channel to publish event: {EventId} ({EventName})", @event.Id, eventName);
+
+        using IModel channel = _persistentConnection.CreateModel();
+        _logger.LogTrace("Declaring RabbitMQ exchange to publish event: {EventId}", @event.Id);
+
+        channel.ExchangeDeclare(exchange: BROKER_NAME, type: "direct");
+
+        byte[] body = JsonSerializer.SerializeToUtf8Bytes(@event, @event.GetType(), new JsonSerializerOptions
+        {
+            WriteIndented = true,
+        });
+
+        policy.Execute(() =>
+        {
+            IBasicProperties properties = channel.CreateBasicProperties();
+            properties.DeliveryMode = 2; // persistent
+
+            _logger.LogTrace("Publishing event to RabbitMQ: {EventId}", @event.Id);
+
+            channel.BasicPublish(
+                exchange: BROKER_NAME,
+                routingKey: eventName,
+                mandatory: true,
+                basicProperties: properties,
+                body: body);
+        });
+    }
+
+    public void SubscribeDynamic<TH>(string eventName)
+        where TH : IDynamicIntegrationEventHandler
+    {
+        _logger.LogInformation("Subscribing to dynamic event {EventName} with {EventHandler}", eventName, typeof(TH).GetGenericTypeName());
+
+        DoInternalSubscription(eventName);
+        _subsManager.AddDynamicSubscription<TH>(eventName);
+        StartBasicConsume();
+    }
+
+    public void Subscribe<T, TH>()
+        where T : IntegrationEvent
+        where TH : IIntegrationEventHandler<T>
+    {
+        string eventName = _subsManager.GetEventKey<T>();
+        DoInternalSubscription(eventName);
+
+        _logger.LogInformation("Subscribing to event {EventName} with {EventHandler}", eventName, typeof(TH).GetGenericTypeName());
+
+        _subsManager.AddSubscription<T, TH>();
+        StartBasicConsume();
+    }
+
+    private void DoInternalSubscription(string eventName)
+    {
+        bool containsKey = _subsManager.HasSubscriptionsForEvent(eventName);
+        if (!containsKey)
+        {
+            if (!_persistentConnection.IsConnected)
+            {
+                _ = _persistentConnection.TryConnect();
+            }
+
+            _consumerChannel.QueueBind(
+                queue: _queueName,
+                exchange: BROKER_NAME,
+                routingKey: eventName);
+        }
+    }
+
+    public void Unsubscribe<T, TH>()
+        where T : IntegrationEvent
+        where TH : IIntegrationEventHandler<T>
+    {
+        string eventName = _subsManager.GetEventKey<T>();
+
+        _logger.LogInformation("Unsubscribing from event {EventName}", eventName);
+
+        _subsManager.RemoveSubscription<T, TH>();
+    }
+
+    public void UnsubscribeDynamic<TH>(string eventName)
+        where TH : IDynamicIntegrationEventHandler
+    {
+        _subsManager.RemoveDynamicSubscription<TH>(eventName);
+    }
+
+    public void Dispose()
+    {
+        _consumerChannel?.Dispose();
+
+        _subsManager.Clear();
+    }
+
+    private void StartBasicConsume()
+    {
+        _logger.LogTrace("Starting RabbitMQ basic consume");
+
+        if (_consumerChannel != null)
+        {
+            AsyncEventingBasicConsumer consumer = new(_consumerChannel);
+
+            consumer.Received += Consumer_Received;
+
+            _ = _consumerChannel.BasicConsume(
+                queue: _queueName,
+                autoAck: false,
+                consumer: consumer);
+        }
+        else
+        {
+            _logger.LogError("StartBasicConsume can't call on _consumerChannel == null");
+        }
+    }
+
+    private async Task Consumer_Received(object sender, BasicDeliverEventArgs eventArgs)
+    {
+        string eventName = eventArgs.RoutingKey;
+        string message = Encoding.UTF8.GetString(eventArgs.Body.Span);
+
+        try
+        {
+            if (message.Contains("throw-fake-exception", StringComparison.InvariantCultureIgnoreCase))
+            {
+                throw new InvalidOperationException($"Fake exception requested: \"{message}\"");
+            }
+
+            await ProcessEvent(eventName, message);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "----- ERROR Processing message \"{Message}\"", message);
+        }
+
+        // Even on exception we take the message off the queue.
+        // in a REAL WORLD app this should be handled with a Dead Letter Exchange (DLX).
+        // For more information see: https://www.rabbitmq.com/dlx.html
+        _consumerChannel.BasicAck(eventArgs.DeliveryTag, multiple: false);
+    }
+
+    private IModel CreateConsumerChannel()
+    {
+        if (!_persistentConnection.IsConnected)
+        {
+            _ = _persistentConnection.TryConnect();
+        }
+
+        _logger.LogTrace("Creating RabbitMQ consumer channel");
+
+        IModel channel = _persistentConnection.CreateModel();
+
+        channel.ExchangeDeclare(
+            exchange: BROKER_NAME,
+            type: "direct");
+
+        _ = channel.QueueDeclare(
+            queue: _queueName,
+            durable: true,
+            exclusive: false,
+            autoDelete: false,
+            arguments: null);
+
+        channel.CallbackException += (sender, ea) =>
+        {
+            _logger.LogWarning(ea.Exception, "Recreating RabbitMQ consumer channel");
+
+            _consumerChannel.Dispose();
+            _consumerChannel = CreateConsumerChannel();
+            StartBasicConsume();
+        };
+
+        return channel;
+    }
+
+    private async Task ProcessEvent(string eventName, string message)
+    {
+        _logger.LogTrace("Processing RabbitMQ event: {EventName}", eventName);
+
+        if (_subsManager.HasSubscriptionsForEvent(eventName))
+        {
+            await using ILifetimeScope scope = _autofac.BeginLifetimeScope(AUTOFAC_SCOPE_NAME);
+            IEnumerable<InMemoryEventBusSubscriptionsManager.SubscriptionInfo> subscriptions = _subsManager.GetHandlersForEvent(eventName);
+            foreach (InMemoryEventBusSubscriptionsManager.SubscriptionInfo subscription in subscriptions)
+            {
+                if (subscription.IsDynamic)
+                {
+                    if (scope.ResolveOptional(subscription.HandlerType) is not IDynamicIntegrationEventHandler handler)
+                    {
+                        continue;
+                    }
+
+                    using dynamic eventData = JsonDocument.Parse(message);
+                    await Task.Yield();
+                    await handler.Handle(eventData);
+                }
+                else
+                {
+                    object? handler = scope.ResolveOptional(subscription.HandlerType);
+                    if (handler == null)
+                    {
+                        continue;
+                    }
+
+                    Type eventType = _subsManager.GetEventTypeByName(eventName);
+                    object? integrationEvent = JsonSerializer.Deserialize(message, eventType, new JsonSerializerOptions() { PropertyNameCaseInsensitive = true });
+                    Type concreteType = typeof(IIntegrationEventHandler<>).MakeGenericType(eventType);
+
+                    await Task.Yield();
+                    await (Task)concreteType.GetMethod("Handle").Invoke(handler, [integrationEvent]);
+                }
+            }
+        }
+        else
+        {
+            _logger.LogWarning("No subscription for RabbitMQ event: {EventName}", eventName);
+        }
+    }
+}

--- a/src/TunNetCom.AionTime.SharedKernel/TunNetCom.AionTime.SharedKernel/EventBusRabbitMQ/Extensions/IEventBusSubscriptionsManager.cs
+++ b/src/TunNetCom.AionTime.SharedKernel/TunNetCom.AionTime.SharedKernel/EventBusRabbitMQ/Extensions/IEventBusSubscriptionsManager.cs
@@ -1,0 +1,47 @@
+﻿using static TunNetCom.AionTime.SharedKernel.EventBusRabbitMQ.Extensions.InMemoryEventBusSubscriptionsManager;
+
+namespace TunNetCom.AionTime.SharedKernel.EventBusRabbitMQ.Extensions;
+
+public interface IEventBusSubscriptionsManager
+{
+    event EventHandler<EventRemovedEventArgs> OnEventRemoved;
+
+    event EventHandler<string> OnEventRemoved;
+
+    bool IsEmpty { get; }
+
+    void AddDynamicSubscription<TH>(string eventName)
+        where TH : IDynamicIntegrationEventHandler;
+
+    void AddSubscription<T, TH>()
+        where T : IntegrationEvent
+        where TH : IIntegrationEventHandler<T>;
+
+    void RemoveSubscription<T, TH>()
+            where TH : IIntegrationEventHandler<T>
+            where T : IntegrationEvent;
+
+    void RemoveDynamicSubscription<TH>(string eventName)
+        where TH : IDynamicIntegrationEventHandler;
+
+    bool HasSubscriptionsForEvent<T>()
+        where T : IntegrationEvent;
+
+    bool HasSubscriptionsForEvent(string eventName);
+
+    Type GetEventTypeByName(string eventName);
+
+    void Clear();
+
+    IEnumerable<SubscriptionInfo> GetHandlersForEvent<T>()
+        where T : IntegrationEvent;
+
+    IEnumerable<SubscriptionInfo> GetHandlersForEvent(string eventName);
+
+    string GetEventKey<T>();
+}
+
+public class EventRemovedEventArgs(string eventName) : EventArgs
+{
+    public string EventName { get; } = eventName;
+}

--- a/src/TunNetCom.AionTime.SharedKernel/TunNetCom.AionTime.SharedKernel/EventBusRabbitMQ/Extensions/InMemoryEventBusSubscriptionsManager.cs
+++ b/src/TunNetCom.AionTime.SharedKernel/TunNetCom.AionTime.SharedKernel/EventBusRabbitMQ/Extensions/InMemoryEventBusSubscriptionsManager.cs
@@ -1,0 +1,165 @@
+﻿namespace TunNetCom.AionTime.SharedKernel.EventBusRabbitMQ.Extensions;
+
+public partial class InMemoryEventBusSubscriptionsManager : IEventBusSubscriptionsManager
+{
+    private readonly Dictionary<string, List<SubscriptionInfo>> _handlers;
+    private readonly List<Type> _eventTypes;
+
+    public InMemoryEventBusSubscriptionsManager()
+    {
+        _handlers = [];
+        _eventTypes = [];
+    }
+
+    public event EventHandler<string> OnEventRemoved;
+
+    public bool IsEmpty => _handlers is { Count: 0 };
+
+    public void Clear()
+    {
+        _handlers.Clear();
+    }
+
+    public void AddDynamicSubscription<TH>(string eventName)
+        where TH : IDynamicIntegrationEventHandler
+    {
+        DoAddSubscription(typeof(TH), eventName, isDynamic: true);
+    }
+
+    public void AddSubscription<T, TH>()
+        where T : IntegrationEvent
+        where TH : IIntegrationEventHandler<T>
+    {
+        string eventName = GetEventKey<T>();
+
+        DoAddSubscription(typeof(TH), eventName, isDynamic: false);
+
+        if (!_eventTypes.Contains(typeof(T)))
+        {
+            _eventTypes.Add(typeof(T));
+        }
+    }
+
+    private void DoAddSubscription(Type handlerType, string eventName, bool isDynamic)
+    {
+        if (!HasSubscriptionsForEvent(eventName))
+        {
+            _handlers.Add(eventName, []);
+        }
+
+        if (_handlers[eventName].Any(s => s.HandlerType == handlerType))
+        {
+            throw new ArgumentException(
+                $"Handler Type {handlerType.Name} already registered for '{eventName}'", nameof(handlerType));
+        }
+
+        if (isDynamic)
+        {
+            _handlers[eventName].Add(SubscriptionInfo.Dynamic(handlerType));
+        }
+        else
+        {
+            _handlers[eventName].Add(SubscriptionInfo.Typed(handlerType));
+        }
+    }
+
+    public void RemoveDynamicSubscription<TH>(string eventName)
+        where TH : IDynamicIntegrationEventHandler
+    {
+        SubscriptionInfo handlerToRemove = FindDynamicSubscriptionToRemove<TH>(eventName);
+        DoRemoveHandler(eventName, handlerToRemove);
+    }
+
+    public void RemoveSubscription<T, TH>()
+        where TH : IIntegrationEventHandler<T>
+        where T : IntegrationEvent
+    {
+        SubscriptionInfo handlerToRemove = FindSubscriptionToRemove<T, TH>();
+        string eventName = GetEventKey<T>();
+        DoRemoveHandler(eventName, handlerToRemove);
+    }
+
+    private void DoRemoveHandler(string eventName, SubscriptionInfo subsToRemove)
+    {
+        if (subsToRemove != null)
+        {
+            _ = _handlers[eventName].Remove(subsToRemove);
+
+            if (!_handlers[eventName].Any())
+            {
+                _ = _handlers.Remove(eventName);
+                Type? eventType = _eventTypes.SingleOrDefault(e => e.Name == eventName);
+                if (eventType != null)
+                {
+                    _ = _eventTypes.Remove(eventType);
+                }
+
+                RaiseOnEventRemoved(eventName);
+            }
+        }
+    }
+
+    public IEnumerable<SubscriptionInfo> GetHandlersForEvent<T>()
+        where T : IntegrationEvent
+    {
+        string key = GetEventKey<T>();
+        return GetHandlersForEvent(key);
+    }
+
+    public IEnumerable<SubscriptionInfo> GetHandlersForEvent(string eventName)
+    {
+        return _handlers[eventName];
+    }
+
+    private void RaiseOnEventRemoved(string eventName)
+    {
+        EventHandler<string> handler = OnEventRemoved;
+        handler?.Invoke(this, eventName);
+    }
+
+    private SubscriptionInfo FindDynamicSubscriptionToRemove<TH>(string eventName)
+        where TH : IDynamicIntegrationEventHandler
+    {
+        return DoFindSubscriptionToRemove(eventName, typeof(TH));
+    }
+
+    private SubscriptionInfo FindSubscriptionToRemove<T, TH>()
+            where T : IntegrationEvent
+            where TH : IIntegrationEventHandler<T>
+    {
+        string eventName = GetEventKey<T>();
+        return DoFindSubscriptionToRemove(eventName, typeof(TH));
+    }
+
+    private SubscriptionInfo? DoFindSubscriptionToRemove(string eventName, Type handlerType)
+    {
+        if (!HasSubscriptionsForEvent(eventName))
+        {
+            return null;
+        }
+
+        return _handlers[eventName].SingleOrDefault(s => s.HandlerType == handlerType);
+    }
+
+    public bool HasSubscriptionsForEvent<T>()
+        where T : IntegrationEvent
+    {
+        string key = GetEventKey<T>();
+        return HasSubscriptionsForEvent(key);
+    }
+
+    public bool HasSubscriptionsForEvent(string eventName)
+    {
+        return _handlers.ContainsKey(eventName);
+    }
+
+    public Type GetEventTypeByName(string eventName)
+    {
+        return _eventTypes.SingleOrDefault(t => t.Name == eventName);
+    }
+
+    public string GetEventKey<T>()
+    {
+        return typeof(T).Name;
+    }
+}

--- a/src/TunNetCom.AionTime.SharedKernel/TunNetCom.AionTime.SharedKernel/EventBusRabbitMQ/Extensions/SubscriptionInfo.cs
+++ b/src/TunNetCom.AionTime.SharedKernel/TunNetCom.AionTime.SharedKernel/EventBusRabbitMQ/Extensions/SubscriptionInfo.cs
@@ -1,0 +1,27 @@
+﻿namespace TunNetCom.AionTime.SharedKernel.EventBusRabbitMQ.Extensions;
+
+public partial class InMemoryEventBusSubscriptionsManager : IEventBusSubscriptionsManager
+{
+    public class SubscriptionInfo
+    {
+        public bool IsDynamic { get; }
+
+        public Type HandlerType { get; }
+
+        private SubscriptionInfo(bool isDynamic, Type handlerType)
+        {
+            IsDynamic = isDynamic;
+            HandlerType = handlerType;
+        }
+
+        public static SubscriptionInfo Dynamic(Type handlerType)
+        {
+            return new SubscriptionInfo(true, handlerType);
+        }
+
+        public static SubscriptionInfo Typed(Type handlerType)
+        {
+            return new SubscriptionInfo(false, handlerType);
+        }
+    }
+}

--- a/src/TunNetCom.AionTime.SharedKernel/TunNetCom.AionTime.SharedKernel/EventBusRabbitMQ/GlobalUsings.cs
+++ b/src/TunNetCom.AionTime.SharedKernel/TunNetCom.AionTime.SharedKernel/EventBusRabbitMQ/GlobalUsings.cs
@@ -1,0 +1,14 @@
+﻿global using Autofac;
+global using Microsoft.Extensions.Logging;
+global using Polly;
+global using Polly.Retry;
+global using RabbitMQ.Client;
+global using RabbitMQ.Client.Events;
+global using RabbitMQ.Client.Exceptions;
+global using System;
+global using System.IO;
+global using System.Text;
+global using System.Text.Json;
+global using TunNetCom.AionTime.SharedKernel.EventBus.Extensions;
+global using TunNetCom.AionTime.SharedKernel.EventBusRabbitMQ;
+global using TunNetCom.AionTime.SharedKernel.EventBusRabbitMQ.Extensions;

--- a/src/TunNetCom.AionTime.SharedKernel/TunNetCom.AionTime.SharedKernel/EventBusRabbitMQ/IRabbitMQPersistentConnection.cs
+++ b/src/TunNetCom.AionTime.SharedKernel/TunNetCom.AionTime.SharedKernel/EventBusRabbitMQ/IRabbitMQPersistentConnection.cs
@@ -1,0 +1,13 @@
+﻿using TunNetCom.AionTime.SharedKernel.EventBusRabbitMQ;
+
+namespace TunNetCom.AionTime.SharedKernel.EventBusRabbitMQ;
+
+public interface IRabbitMQPersistentConnection
+    : IDisposable
+{
+    bool IsConnected { get; }
+
+    bool TryConnect();
+
+    IModel CreateModel();
+}

--- a/src/TunNetCom.AionTime.SharedKernel/TunNetCom.AionTime.SharedKernel/ExtentionRegistrationService.cs
+++ b/src/TunNetCom.AionTime.SharedKernel/TunNetCom.AionTime.SharedKernel/ExtentionRegistrationService.cs
@@ -1,0 +1,76 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace TunNetCom.AionTime.SharedKernel;
+
+public static class ExtentionRegistrationService
+{
+    public static IServiceCollection AddRabbitMQ(
+        this IServiceCollection services,
+        Action<RabbitMQOptions> configure,
+        Action<IEventBus>? configureSubscriptions = null)
+    {
+        RabbitMQOptions options = new()
+        {
+            EventBusPassword = "AionTime",
+            EventBusUserName = "AionTime",
+            EventBusConnection = "localhost",
+            ServiceName = "Mayservice",
+        };
+        configure?.Invoke(options);
+        _ = services.AddSingleton<IRabbitMQPersistentConnection>(sp =>
+        {
+            ILogger<DefaultRabbitMQPersistentConnection> logger = sp.GetRequiredService<ILogger<DefaultRabbitMQPersistentConnection>>();
+
+            ConnectionFactory factory = new()
+            {
+                HostName = options.EventBusConnection,
+                DispatchConsumersAsync = true,
+            };
+
+            if (!string.IsNullOrEmpty(options.EventBusConnection))
+            {
+                factory.UserName = options.EventBusUserName;
+            }
+
+            if (!string.IsNullOrEmpty(options.EventBusPassword))
+            {
+                factory.Password = options.EventBusPassword;
+            }
+
+            return new DefaultRabbitMQPersistentConnection(factory, logger, options.EventBusRetryCount);
+        });
+        _ = services.AddSingleton<IEventBus, EventBusRabbitMQService>(sp =>
+        {
+            IRabbitMQPersistentConnection rabbitMQPersistentConnection = sp.GetRequiredService<IRabbitMQPersistentConnection>();
+            ILifetimeScope iLifetimeScope = sp.GetRequiredService<ILifetimeScope>();
+            ILogger<EventBusRabbitMQService> logger = sp.GetRequiredService<ILogger<EventBusRabbitMQService>>();
+            IEventBusSubscriptionsManager eventBusSubscriptionsManager = sp.GetRequiredService<IEventBusSubscriptionsManager>();
+
+            return new EventBusRabbitMQService(rabbitMQPersistentConnection, logger, iLifetimeScope, eventBusSubscriptionsManager, options.ServiceName, options.EventBusRetryCount);
+        });
+
+        _ = services.AddSingleton<IEventBus>(sp =>
+        {
+            IRabbitMQPersistentConnection rabbitMQPersistentConnection = sp.GetRequiredService<IRabbitMQPersistentConnection>();
+            ILifetimeScope lifetimeScope = sp.GetRequiredService<ILifetimeScope>();
+            ILogger<EventBusRabbitMQService> logger = sp.GetRequiredService<ILogger<EventBusRabbitMQService>>();
+            IEventBusSubscriptionsManager eventBusSubscriptionsManager = sp.GetRequiredService<IEventBusSubscriptionsManager>();
+
+            EventBusRabbitMQService eventBus = new(
+                rabbitMQPersistentConnection,
+                logger,
+                lifetimeScope,
+                eventBusSubscriptionsManager,
+                options.ServiceName,
+                options.EventBusRetryCount);
+
+            configureSubscriptions?.Invoke(eventBus);
+
+            return eventBus;
+        });
+
+        _ = services.AddSingleton<IEventBusSubscriptionsManager, InMemoryEventBusSubscriptionsManager>();
+
+        return services;
+    }
+}

--- a/src/TunNetCom.AionTime.SharedKernel/TunNetCom.AionTime.SharedKernel/GlobalUsings.cs
+++ b/src/TunNetCom.AionTime.SharedKernel/TunNetCom.AionTime.SharedKernel/GlobalUsings.cs
@@ -1,4 +1,5 @@
-﻿global using Microsoft.Extensions.DependencyInjection;
+﻿global using Microsoft.Extensions.Configuration;
+global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.Logging;
 global using Microsoft.Extensions.Options;
 global using Polly;
@@ -19,3 +20,5 @@ global using System.Text.Json.Serialization.Metadata;
 global using System.Threading.Tasks;
 global using TunNetCom.AionTime.SharedKernel.EventBus.Abstractions;
 global using TunNetCom.AionTime.SharedKernel.EventBus.Events;
+global using TunNetCom.AionTime.SharedKernel.EventBusRabbitMQ;
+global using TunNetCom.AionTime.SharedKernel.EventBusRabbitMQ.Extensions;

--- a/src/TunNetCom.AionTime.SharedKernel/TunNetCom.AionTime.SharedKernel/RabbitMQOptions.cs
+++ b/src/TunNetCom.AionTime.SharedKernel/TunNetCom.AionTime.SharedKernel/RabbitMQOptions.cs
@@ -1,0 +1,14 @@
+﻿namespace TunNetCom.AionTime.SharedKernel;
+
+public class RabbitMQOptions
+{
+    public required string EventBusUserName { get; set; }
+
+    public required string EventBusPassword { get; set; }
+
+    public int EventBusRetryCount { get; set; } = 0;
+
+    public required string ServiceName { get; set; }
+
+    public string EventBusConnection { get; set; } = "localhost";
+}

--- a/src/TunNetCom.AionTime.SharedKernel/TunNetCom.AionTime.SharedKernel/TunNetCom.AionTime.SharedKernel.csproj
+++ b/src/TunNetCom.AionTime.SharedKernel/TunNetCom.AionTime.SharedKernel/TunNetCom.AionTime.SharedKernel.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Autofac" Version="8.2.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />


### PR DESCRIPTION
This commit introduces RabbitMQ for event handling in the Azure DevOps and TimeLog services. Key changes include:

- Added `AddRabbitMQ` method in `ExtentionRegistrationService.cs` for RabbitMQ configuration, replacing the previous MassTransit setup.
- Implemented RabbitMQ configuration in `ApplicationServiceRegistration.cs` to support event subscriptions.
- Expanded the `IEventBus` interface to include subscription methods.
- Introduced new classes: `RabbitMQOptions`, `DefaultRabbitMQPersistentConnection`, and `EventBusRabbitMQService` for managing RabbitMQ connections and event bus functionality.
- Updated `InMemoryEventBusSubscriptionsManager` for dynamic event subscription management.
- Modified global usings and project file to include necessary RabbitMQ and dependency injection namespaces and libraries.

These changes enhance the event-driven architecture, improving scalability and maintainability.